### PR TITLE
Add TabPFN regression demo notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,14 @@ r2 = r2_score(y_test, predictions)
 
 print("Mean Squared Error (MSE):", mse)
 print("R² Score:", r2)
+
+# 95% confidence interval for the predictions
+lower, upper = regressor.predict(
+    X_test,
+    output_type="quantiles",
+    quantiles=[0.025, 0.975],
+)
+print("First sample interval:", lower[0], "-", upper[0])
 ```
 
 ### Best Results

--- a/examples/tabpfn_for_regression.py
+++ b/examples/tabpfn_for_regression.py
@@ -43,3 +43,16 @@ for q, q_pred in zip(quantiles, quantile_predictions):
 # Predict with mode
 mode_predictions = reg.predict(X_test, output_type="mode")
 print("Mode MAE:", mean_absolute_error(y_test, mode_predictions))
+
+# Predict a 95% confidence interval using quantiles
+ci_quantiles = [0.025, 0.975]
+ci_lower, ci_upper = reg.predict(
+    X_test,
+    output_type="quantiles",
+    quantiles=ci_quantiles,
+)
+for idx in range(5):
+    print(
+        f"Pred {idx}: {predictions[idx]:.2f}"
+        f"\tCI [{ci_lower[idx]:.2f}, {ci_upper[idx]:.2f}]"
+    )

--- a/examples/tabpfn_regression_demo.ipynb
+++ b/examples/tabpfn_regression_demo.ipynb
@@ -1,0 +1,144 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1a60b80f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#  Copyright (c) Prior Labs GmbH 2025.\n",
+    "\"\"\"Example of using TabPFN for regression.\n",
+    "\n",
+    "This example demonstrates how to use TabPFNRegressor on a regression task\n",
+    "using the diabetes dataset from scikit-learn.\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "35138295",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.datasets import load_diabetes\n",
+    "from sklearn.metrics import mean_absolute_error, mean_squared_error, r2_score\n",
+    "from sklearn.model_selection import train_test_split"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6965bd2f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from tabpfn import TabPFNRegressor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e8592215",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load data\n",
+    "X, y = load_diabetes(return_X_y=True)\n",
+    "X_train, X_test, y_train, y_test = train_test_split(\n",
+    "    X,\n",
+    "    y,\n",
+    "    test_size=0.33,\n",
+    "    random_state=42,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "19ac779e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Initialize a regressor\n",
+    "reg = TabPFNRegressor()\n",
+    "reg.fit(X_train, y_train)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1e5dabe7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Predict a point estimate (using the mean)\n",
+    "predictions = reg.predict(X_test)\n",
+    "print(\"Mean Squared Error (MSE):\", mean_squared_error(y_test, predictions))\n",
+    "print(\"Mean Absolute Error (MAE):\", mean_absolute_error(y_test, predictions))\n",
+    "print(\"R-squared (R^2):\", r2_score(y_test, predictions))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7198d7d3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Predict quantiles\n",
+    "quantiles = [0.25, 0.5, 0.75]\n",
+    "quantile_predictions = reg.predict(\n",
+    "    X_test,\n",
+    "    output_type=\"quantiles\",\n",
+    "    quantiles=quantiles,\n",
+    ")\n",
+    "for q, q_pred in zip(quantiles, quantile_predictions):\n",
+    "    print(f\"Quantile {q} MAE:\", mean_absolute_error(y_test, q_pred))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6c576f91",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Predict with mode\n",
+    "mode_predictions = reg.predict(X_test, output_type=\"mode\")\n",
+    "print(\"Mode MAE:\", mean_absolute_error(y_test, mode_predictions))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "25e4c4fd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Predict a 95% confidence interval using quantiles\n",
+    "ci_quantiles = [0.025, 0.975]\n",
+    "ci_lower, ci_upper = reg.predict(\n",
+    "    X_test,\n",
+    "    output_type=\"quantiles\",\n",
+    "    quantiles=ci_quantiles,\n",
+    ")\n",
+    "for idx in range(5):\n",
+    "    print(\n",
+    "        f\"Pred {idx}: {predictions[idx]:.2f}\"\n",
+    "        f\"\\tCI [{ci_lower[idx]:.2f}, {ci_upper[idx]:.2f}]\"\n",
+    "    )"
+   ]
+  }
+ ],
+ "metadata": {
+  "jupytext": {
+   "cell_metadata_filter": "-all",
+   "main_language": "python",
+   "notebook_metadata_filter": "-all"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- provide an example Jupyter notebook for TabPFN regression

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_683fb0775938832d95cd0a87dd566f48